### PR TITLE
Implemented signOut function for SettingsFragment

### DIFF
--- a/app/src/main/java/com/procleus/brime/ui/SettingsActivity.java
+++ b/app/src/main/java/com/procleus/brime/ui/SettingsActivity.java
@@ -20,13 +20,16 @@
 package com.procleus.brime.ui;
 
 import android.app.FragmentManager;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
 import com.procleus.brime.R;
+import com.procleus.brime.login.SigninActivity;
 
 public class SettingsActivity extends AppCompatActivity{
 
@@ -69,6 +72,19 @@ public class SettingsActivity extends AppCompatActivity{
 
     }
 
+    public void signOut(){
+        SharedPreferences sharedpreferences = getSharedPreferences(SigninActivity.PREF, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedpreferences.edit();
+        editor.remove("emailpref");
+        editor.remove("passwordpref");
+        editor.remove("loggedin");
+        editor.commit();
+        Intent intent = new Intent(this, SigninActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        // intent.putExtra("EXIT", true);
+        startActivity(intent);
+         finish();
+   }
     public void setActionBarTitle(String title) {
         getSupportActionBar().setTitle(title);
     }

--- a/app/src/main/java/com/procleus/brime/ui/SettingsFragment.java
+++ b/app/src/main/java/com/procleus/brime/ui/SettingsFragment.java
@@ -61,9 +61,6 @@ public class SettingsFragment extends PreferenceFragment {
 
     }
 
-    public void signOut() {
-    }
-
     private class SettingsClickListener implements Preference.OnPreferenceClickListener{
 
         private String option;
@@ -87,7 +84,7 @@ public class SettingsFragment extends PreferenceFragment {
                         title="About Us";
                         break;
                     case PREFERENCE_SIGN_OUT:
-                            signOut();
+                        ((SettingsActivity) getActivity()).signOut();
                         break;
                     case PREFERENCE_SHARE:
                         //TODO: share app


### PR DESCRIPTION
<!--
Thanks for submitting a change to BrimeNotes/android!
To make it possible for us to get your change reviewed and merged please fill out below information carefully.
-->

## Description
This PR adds functionality to the SettingsFragment's Sign Out option

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: Issue #95 
## Motivation and Context
To enable user, to be able to sign out from the application

## How Has This Been Tested?
Rigorously tested after compiling the app

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds a new functionality)
- [ ] Code cleanup (non-breaking change which improves the code structure)
- [ ] Breaking change (fix or a feature that would cause the existing functionality to change) 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [x] There is a corresponding issue for this pull request.
- [ ] I have updated the documentation (if required).